### PR TITLE
avoid local writing

### DIFF
--- a/pemfc_dash/main.py
+++ b/pemfc_dash/main.py
@@ -297,13 +297,21 @@ def run_simulation(signal, input_data, modal_state):
     if signal is None:
         raise PreventUpdate
     try:
+        # Initially get default simulation settings from settings.json file
+        # in pemfc core module
         pemfc_base_dir = os.path.dirname(pemfc.__file__)
         with open(os.path.join(pemfc_base_dir, 'settings', 'settings.json')) \
                 as file:
             settings = json.load(file)
+        # Change settings dictionary according to dashboard user input
         settings, name_lists = \
             data_transfer.gui_to_sim_transfer(input_data, settings)
-        global_data, local_data, sim = main_app.main(settings=settings)
+        # Avoid local outputs from simulation
+        settings['output']['save_csv'] = False
+        settings['output']['save_plot'] = False
+        # Run simulation
+        global_data, local_data, sim = main_app.main(settings=settings,
+                                                     save_settings=False)
     except Exception as E:
         modal_title, modal_body = \
             dm.modal_process('input-error', error=repr(E))


### PR DESCRIPTION
The default settings file from the pemfc-core module has "save_plot=True" and "save_csv=True" and the settings.json was always written. Change the pemfc-core accordingly and the boolean values are change in the run_simulation function 