### PR TITLE
Fix yvalues length

### DIFF
--- a/pemfc_dash/main.py
+++ b/pemfc_dash/main.py
@@ -1668,7 +1668,7 @@ def update_line_graph(drop1, drop2, checklist, select_all_clicks,
         else:
             raise PreventUpdate
 
-        n_y = np.asarray(yvalues).shape[0]
+        n_y = np.asarray(yvalues).shape[-1]
         if x_key in local_data:
             xvalues = np.asarray(local_data[x_key]['value'])
             if len(xvalues) == n_y + 1:


### PR DESCRIPTION
using last dimension in 2D array to determine actual 1D array length to plot in line plot: 1st dimension for number of fuel cells, 2nd dimension for elements in array -> so second dimension (last dimension as -1) is used